### PR TITLE
Resolved TypeError(Option values must be a strings) in config.py

### DIFF
--- a/notion_scholar/config.py
+++ b/notion_scholar/config.py
@@ -120,7 +120,7 @@ class ConfigManager:
         }
 
         for key, value in key_to_value.items():
-            if key is not None:
+            if value is not None:
                 config.set(section='Settings', option=key, value=value)
 
         # Save the changes


### PR DESCRIPTION
Hi Thomas, 

I just forked your repo and came across the following issue:

![image](https://user-images.githubusercontent.com/35528307/212113755-69f2be8b-4e37-4687-9a26-730bd0389fe7.png)

Setting the config (_ns set-config ds <database_id>_ or _ns set-config f <bib_path>_) threw an TypeError(Option values must be a strings) in the ArgumentenParser.

The config.py file checked whether the key of the key_to_value dict was None or not. As the keys are always given -- database_id and file_path, setting the config results in the 'Option values must be a strings' TypeError when calling config.set(..). 

Therefore, the config.py checks now whether the value in the key_to_value dict is None and sets the config accordingly.