### PR TITLE
Add -c option to automatically set the category of added references

### DIFF
--- a/notion_scholar/bibtex.py
+++ b/notion_scholar/bibtex.py
@@ -37,7 +37,7 @@ def get_bib_database_from_string(string: str) -> BibDatabase:
         string.
     """
     bibtex_parser = BibTexParser(
-        interpolate_strings=False,
+        # interpolate_strings=False,
         common_strings=True,
         ignore_nonstandard_types=False,
     )

--- a/notion_scholar/config.py
+++ b/notion_scholar/config.py
@@ -23,11 +23,13 @@ class ConfigManager:
             string: Optional[str] = None,
             file_path: Optional[str] = None,
             database_id: Optional[str] = None,
+            categories: Optional[str] = None,
     ):
         self.token = token
         self.string = string
         self.file_path = file_path
         self.database_id = database_id
+        self.categories = categories
 
         directory_path = Path(user_config_dir(appname='notion-scholar'))
         self.config_path = directory_path.joinpath('config').with_suffix('.ini')
@@ -57,7 +59,8 @@ class ConfigManager:
         return {
             'bib_string': self.string,
             'bib_file_path': file_path,
-            **self._get_sanitized_kwargs()
+            **self._get_sanitized_kwargs(),
+            'categories': self.categories,
         }
 
     def _get_sanitized_kwargs(self):

--- a/notion_scholar/config.py
+++ b/notion_scholar/config.py
@@ -47,12 +47,12 @@ class ConfigManager:
 
             if not Path(file_path).exists():
                 raise ConfigException("The file_path provided to the argparse does not exist.")
-        else:
+        elif self.string is None:
             file_path = config.get('file_path', None)
             if file_path is None:
-                raise ConfigException("No file_path provided and no file path set in the config.")
+                raise ConfigException("No file_path or bib string provided and no file path set in the config.")
             if not Path(file_path).exists():
-                raise ConfigException("No file_path provided and the file_path set in the config does not exist.")
+                raise ConfigException("No file_path or bib string provided and the file_path set in the config does not exist.")
 
         return {
             'bib_string': self.string,

--- a/notion_scholar/main.py
+++ b/notion_scholar/main.py
@@ -43,6 +43,14 @@ def get_parser():
              f'https://www.notion.so/{{workspace_name}}/{{database_id}}?v={{view_id}} \n'
              f'(default: {config.get("database_id", None)})',
     )
+    run_parser.add_argument(
+        '-c', '--category',
+        action='append', default=None, type=str, required=False,
+        dest='categories',
+        help='Category of the publications that will be added to the database (provide the category ID). '
+                'It is possible to add multiple categories by passing this argument multiple times. '
+                '(default: no category)'
+    )
 
     if config.get('file_path', None) is None:
         group = run_parser.add_mutually_exclusive_group(required=True)

--- a/notion_scholar/notion_api.py
+++ b/notion_scholar/notion_api.py
@@ -3,6 +3,7 @@ from typing import Any
 from typing import Callable
 from typing import List
 from typing import Union
+from typing import Optional
 
 from notion_client import Client
 
@@ -33,12 +34,17 @@ class Property:
     @staticmethod
     def select(value: str) -> dict:
         return {"select": {"name": value}}
+    
+    @staticmethod
+    def relation(value: List[str]) -> dict:
+        return {"relation": [{"id": v} for v in value]}
 
 
 def add_publications_to_database(
         publications: List[Publication],
         token: str,
         database_id: str,
+        categories: Optional[List[str]] = None,
 ) -> None:
     # todo retrieve the list of all the property and filter
     # todo update_database_with_publications check the empty fields and fill them
@@ -70,6 +76,7 @@ def add_publications_to_database(
                 'Inbox': Property.checkbox(True),
                 'Type': Property.select(publication.type),
                 'DOI': Property.rich_text(publication.doi),
+                **({'Categories': Property.relation(categories)} if categories else {}),
             },
         )
 

--- a/notion_scholar/run.py
+++ b/notion_scholar/run.py
@@ -21,6 +21,7 @@ def run(
         database_id: str,
         bib_file_path: Optional[str] = None,
         bib_string: Optional[str] = None,
+        categories: Optional[List[str]] = None,
 ) -> int:
     if bib_string is not None:
         bib_database: BibDatabase = get_bib_database_from_string(string=bib_string)
@@ -42,6 +43,7 @@ def run(
         publications=publication_list_filtered,
         token=token,
         database_id=database_id,
+        categories=categories,
     )
 
     if not publication_list_filtered and publication_list:

--- a/notion_scholar/run.py
+++ b/notion_scholar/run.py
@@ -19,7 +19,7 @@ class IllegalArgumentException(NotionScholarException):
 def run(
         token: str,
         database_id: str,
-        bib_file_path: Optional[str],
+        bib_file_path: Optional[str] = None,
         bib_string: Optional[str] = None,
 ) -> int:
     if bib_string is not None:


### PR DESCRIPTION
I think it would come in handy to have a "-c" option to set the category of the to-be-imported references. Usage would be, for example:
```bash
ns run -c "CATEGORY_ID" -s """BIBTEX_STRING"""
```